### PR TITLE
fix: always close dropdown on submit

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -41,10 +41,10 @@ export default function Autocomplete({ onSubmit }: Props) {
     if (query.trim()) {
       addQuery(query)
       setInput(query.trim())
-      searchInputRef.current!.blur()
       onSubmit(query)
-      setShowAutocomplete(false)
     }
+    searchInputRef.current!.blur()
+    setShowAutocomplete(false)
   }
 
   return (

--- a/src/entries/injected.tsx
+++ b/src/entries/injected.tsx
@@ -60,14 +60,12 @@ function Autocomplete({ onSubmit }: Props) {
   const { addQuery } = useHistory()
 
   const onSearchSubmit = (query: string) => {
-    if (!query.trim()) {
-      return
+    if (query.trim()) {
+      addQuery(query)
+      searchInput.value = query
+      onSubmit(query)
     }
-
-    addQuery(query)
-    searchInput.value = query
     searchInput.blur()
-    onSubmit(query)
     setShowAutocomplete(false)
   }
 


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Do the following 2 things on submit regardless if a query string is defined or not
* blur the input element
* close the autocomplete dropdown

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->