### PR TITLE
fix(ci): migrate to using app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,14 @@ jobs:
           npx playwright install --with-deps
           npm run test:e2e
 
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request updates the release workflow to use a GitHub App token for authentication instead of the default GitHub token. This change enhances security and allows for more granular permissions during the release process.

**Workflow authentication improvements:**

* Added a step to generate a GitHub App token using the `actions/create-github-app-token` action, utilizing secrets for the app ID and private key.
* Updated the `Semantic Release` step to use the newly created GitHub App token for authentication instead of the default `GITHUB_TOKEN`.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->