### PR TITLE
fix(ci): disable persist credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Node


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request makes a minor update to the GitHub Actions workflow configuration. The change disables credential persistence during the checkout step, which improves security by preventing the workflow from retaining GitHub credentials after the checkout process.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->