### PR TITLE
[codex] fix RangeSelector radio deselection

### DIFF
--- a/src/components/FilterSidebar/RangeSelector/RangeSelector.tsx
+++ b/src/components/FilterSidebar/RangeSelector/RangeSelector.tsx
@@ -57,7 +57,7 @@ export default function RangeSelector({ facet, rangeSize = 100, defaultActive = 
               name={`${facet.id}-range`}
               value={`${rangeItem.min} - ${rangeItem.max}`}
               selected={rangeItem.selected ?? false}
-              onChange={() =>
+              onClick={() =>
                 rangeItem.selected ? updateRange([undefined, undefined]) : updateRange([rangeItem.min, rangeItem.max])
               }
               className={styles.rangeItem}

--- a/src/elements/RadioButton/RadioButton.stories.tsx
+++ b/src/elements/RadioButton/RadioButton.stories.tsx
@@ -17,7 +17,7 @@ export const Default: Story = {
     name: "example",
     value: "Radio Button Label",
     selected: false,
-    onChange: () => {}
+    onClick: () => {}
   }
 }
 
@@ -26,7 +26,7 @@ export const Selected: Story = {
     name: "example",
     value: "Selected Radio Button",
     selected: true,
-    onChange: () => {}
+    onClick: () => {}
   }
 }
 
@@ -35,7 +35,7 @@ export const LongLabel: Story = {
     name: "example",
     value: "This is a radio button with a very long label that might wrap to multiple lines",
     selected: false,
-    onChange: () => {}
+    onClick: () => {}
   }
 }
 
@@ -44,7 +44,7 @@ export const PriceRange: Story = {
     name: "price",
     value: "£0 - £250",
     selected: false,
-    onChange: () => {}
+    onClick: () => {}
   },
   parameters: {
     docs: {

--- a/src/elements/RadioButton/RadioButton.tsx
+++ b/src/elements/RadioButton/RadioButton.tsx
@@ -4,16 +4,16 @@ import { cl } from "@nosto/search-js/utils"
 type Props = {
   value: string
   selected: boolean
-  onChange: (e: Event) => void
+  onClick: (e: MouseEvent) => void
   className?: string
   name: string
 }
 
-export default function RadioButton({ value, selected, onChange, className, name }: Props) {
+export default function RadioButton({ value, selected, onClick, className, name }: Props) {
   return (
     <label className={cl(style.radioButton, className)}>
       {value}
-      <input type="radio" name={name} checked={selected} onChange={onChange} />
+      <input type="radio" name={name} checked={selected} onClick={onClick} />
       <span className={style.checkmark} />
     </label>
   )

--- a/test/elements/RadioButton/RadioButton.spec.tsx
+++ b/test/elements/RadioButton/RadioButton.spec.tsx
@@ -1,0 +1,17 @@
+import { fireEvent, render } from "@testing-library/preact"
+import { describe, expect, it, vi } from "vitest"
+import RadioButton from "@/elements/RadioButton/RadioButton"
+
+describe("RadioButton", () => {
+  it("fires onClick when the selected option is clicked again", () => {
+    const onClick = vi.fn()
+    const { container } = render(<RadioButton name="price" value="0 - 100" selected={true} onClick={onClick} />)
+
+    const input = container.querySelector('input[type="radio"]')
+
+    expect(input).toBeTruthy()
+    fireEvent.click(input!)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- switch RadioButton input handling from change to click so selected radio options can be clicked again
- update RangeSelector to use the click handler for range deselection
- add a RadioButton regression test for repeated clicks on a selected option

## Validation
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run lint
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run typecheck
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run test
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run test:e2e