### PR TITLE
[codex] standardize CSS module import aliases

### DIFF
--- a/src/components/Autocomplete/Item/Category.tsx
+++ b/src/components/Autocomplete/Item/Category.tsx
@@ -1,5 +1,5 @@
 import { SearchCategory } from "@nosto/nosto-js/client"
-import style from "./Item.module.css"
+import styles from "./Item.module.css"
 import { AutocompleteElement } from "@nosto/search-js/preact/autocomplete"
 
 type CategoryProps = {
@@ -14,7 +14,7 @@ export default function Category({ category }: CategoryProps) {
       as="a"
       componentProps={{
         href: category.url,
-        className: style.item,
+        className: styles.item,
         "aria-label": `Category ${category.fullName ?? category.name}`
       }}
     >

--- a/src/components/Autocomplete/Item/Keyword.tsx
+++ b/src/components/Autocomplete/Item/Keyword.tsx
@@ -1,6 +1,6 @@
 import { AutocompleteElement } from "@nosto/search-js/preact/autocomplete"
 import { SearchKeyword } from "@nosto/nosto-js/client"
-import style from "./Item.module.css"
+import styles from "./Item.module.css"
 import { useOnSubmit } from "../OnSubmitContext"
 
 type KeywordProps = {
@@ -13,7 +13,7 @@ export default function Keyword({ keyword }: KeywordProps) {
     <AutocompleteElement
       hit={keyword}
       componentProps={{
-        className: style.item,
+        className: styles.item,
         onClick: (e: Event) => {
           e.preventDefault()
           if (keyword._redirect) {

--- a/src/components/Autocomplete/Item/PopularSearch.tsx
+++ b/src/components/Autocomplete/Item/PopularSearch.tsx
@@ -1,6 +1,6 @@
 import { AutocompleteElement } from "@nosto/search-js/preact/autocomplete"
 import { SearchPopularSearch } from "@nosto/nosto-js/client"
-import style from "./Item.module.css"
+import styles from "./Item.module.css"
 import { useOnSubmit } from "../OnSubmitContext"
 
 type PopularSearchProps = {
@@ -13,7 +13,7 @@ export default function PopularSearch({ search }: PopularSearchProps) {
     <AutocompleteElement
       hit={{ keyword: search.query! }}
       componentProps={{
-        className: style.item,
+        className: styles.item,
         onClick: (e: Event) => {
           e.preventDefault()
           onSubmit(search.query!, { isPopular: true })

--- a/src/components/Autocomplete/Item/Product.tsx
+++ b/src/components/Autocomplete/Item/Product.tsx
@@ -1,5 +1,5 @@
 import { AutocompleteElement } from "@nosto/search-js/preact/autocomplete"
-import style from "./Product.module.css"
+import styles from "./Product.module.css"
 import type { Product } from "@/types"
 
 type Props = {
@@ -17,18 +17,18 @@ export default function Product({ hit }: Props) {
       as="a"
       componentProps={{
         "aria-label": `Product ${hit.name}`,
-        className: style.container,
+        className: styles.container,
         href: hit.url
       }}
     >
-      <img className={style.image} src={hit.imageUrl} alt={hit.name} />
-      <div className={style.details} data-nosto-element="product">
+      <img className={styles.image} src={hit.imageUrl} alt={hit.name} />
+      <div className={styles.details} data-nosto-element="product">
         {hit.brand && <div>{hit.brand}</div>}
-        <div className={style.name}>{hit.name}</div>
-        <div className={style.price}>
+        <div className={styles.name}>{hit.name}</div>
+        <div className={styles.price}>
           <span>{hit.priceText}</span>
           {hit.listPrice && hit.price && hit.listPrice > hit.price && (
-            <span className={style.strikedPrice}>{hit.listPriceText}</span>
+            <span className={styles.strikedPrice}>{hit.listPriceText}</span>
           )}
         </div>
       </div>

--- a/src/components/Autocomplete/Results/Categories.tsx
+++ b/src/components/Autocomplete/Results/Categories.tsx
@@ -1,7 +1,7 @@
 import { SearchCategories } from "@nosto/nosto-js/client"
 import Heading from "@/elements/Heading/Heading"
 import Category from "../Item/Category"
-import style from "./Results.module.css"
+import styles from "./Results.module.css"
 
 export type CategoriesProps = {
   categories: SearchCategories
@@ -13,9 +13,9 @@ export default function Categories({ categories }: CategoriesProps) {
   }
 
   return (
-    <div className={style.suggestionsColumn}>
+    <div className={styles.suggestionsColumn}>
       <Heading>Categories</Heading>
-      <div className={style.keywords}>
+      <div className={styles.keywords}>
         {categories.hits.map((category, index) => (
           <Category category={category} key={index} />
         ))}

--- a/src/components/Autocomplete/Results/Keywords.tsx
+++ b/src/components/Autocomplete/Results/Keywords.tsx
@@ -1,7 +1,7 @@
 import { SearchKeywords } from "@nosto/nosto-js/client"
 import Heading from "@/elements/Heading/Heading"
 import Keyword from "@/components/Autocomplete/Item/Keyword"
-import style from "./Results.module.css"
+import styles from "./Results.module.css"
 
 export type KeywordsProps = {
   keywords: SearchKeywords
@@ -13,9 +13,9 @@ export default function Keywords({ keywords }: KeywordsProps) {
   }
 
   return (
-    <div className={style.suggestionsColumn}>
+    <div className={styles.suggestionsColumn}>
       <Heading>Suggestions</Heading>
-      <div className={style.keywords}>
+      <div className={styles.keywords}>
         {keywords.hits.map((keyword, index) => (
           <Keyword key={index} keyword={keyword} />
         ))}

--- a/src/components/Autocomplete/Results/PopularSearches.tsx
+++ b/src/components/Autocomplete/Results/PopularSearches.tsx
@@ -1,6 +1,6 @@
 import { SearchPopularSearches } from "@nosto/nosto-js/client"
 import Heading from "@/elements/Heading/Heading"
-import style from "./Results.module.css"
+import styles from "./Results.module.css"
 import PopularSearch from "../Item/PopularSearch"
 
 export type SearchesProps = {
@@ -13,9 +13,9 @@ export default function PopularSearches({ searches }: SearchesProps) {
   }
 
   return (
-    <div className={style.suggestionsColumn}>
+    <div className={styles.suggestionsColumn}>
       <Heading>Popular searches</Heading>
-      <div className={style.keywords}>
+      <div className={styles.keywords}>
         {searches.hits.map(search => (
           <PopularSearch key={search.query} search={search} />
         ))}

--- a/src/components/Autocomplete/Results/Products.tsx
+++ b/src/components/Autocomplete/Results/Products.tsx
@@ -2,7 +2,7 @@ import { SearchProducts } from "@nosto/nosto-js/client"
 import Button from "@/elements/Button/Button"
 import Heading from "@/elements/Heading/Heading"
 import Product from "@/components/Autocomplete/Item/Product"
-import style from "./Results.module.css"
+import styles from "./Results.module.css"
 
 export type ProductsProps = {
   products: SearchProducts
@@ -14,15 +14,15 @@ export default function Products({ products }: ProductsProps) {
   }
 
   return (
-    <div className={style.productsColumn}>
+    <div className={styles.productsColumn}>
       <Heading>Products</Heading>
-      <div className={style.products}>
+      <div className={styles.products}>
         {products.hits.map(hit => (
           <Product key={hit.productId} hit={hit} />
         ))}
       </div>
-      <div className={style.button}>
-        <Button type="submit" className={style.submit}>
+      <div className={styles.button}>
+        <Button type="submit" className={styles.submit}>
           See all search results
         </Button>
       </div>

--- a/src/components/Autocomplete/Results/Results.tsx
+++ b/src/components/Autocomplete/Results/Results.tsx
@@ -1,5 +1,5 @@
 import { useNostoAppState, useResponse } from "@nosto/search-js/preact/hooks"
-import style from "./Results.module.css"
+import styles from "./Results.module.css"
 import Keywords from "./Keywords"
 import Products from "./Products"
 import History from "./History"
@@ -29,10 +29,10 @@ export default function Results({ onKeyDown }: ResultsProps) {
 
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-    <div className={style.autocomplete} data-nosto-element="autocomplete" onKeyDown={onKeyDown}>
-      <div className={`${style.container} ${style.paddingContainer}`} ref={containerRef}>
-        <div className={style.items}>
-          <div className={style.section}>
+    <div className={styles.autocomplete} data-nosto-element="autocomplete" onKeyDown={onKeyDown}>
+      <div className={`${styles.container} ${styles.paddingContainer}`} ref={containerRef}>
+        <div className={styles.items}>
+          <div className={styles.section}>
             {hasHistory && <History />}
             {hasResults && <Keywords keywords={keywords} />}
             {hasResults && <Categories categories={categories} />}

--- a/src/components/NoResults/NoResults.tsx
+++ b/src/components/NoResults/NoResults.tsx
@@ -1,11 +1,11 @@
 import { useNostoAppState } from "@nosto/search-js/preact/hooks"
-import style from "./NoResults.module.css"
+import styles from "./NoResults.module.css"
 
 export default function NoResults() {
   const query = useNostoAppState(state => state.response.query)
 
   return (
-    <div className={style.container}>
+    <div className={styles.container}>
       <div>No results found for &apos;{query}&apos;</div>
     </div>
   )

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,7 +1,7 @@
 import { usePagination, useActions, Page } from "@nosto/search-js/preact/hooks"
 import Icon from "@/elements/Icon/Icon"
 import { JSX } from "preact/jsx-runtime"
-import style from "./Pagination.module.css"
+import styles from "./Pagination.module.css"
 import { getPageUrl } from "@/mapping/url/getPageUrl"
 import { cl } from "@nosto/search-js/utils"
 
@@ -11,7 +11,7 @@ type Props = {
 
 function PageLink({ onClick, href, className, ariaLabel, children }: Props) {
   return (
-    <a className={cl(style.link, className)} href={href} aria-label={ariaLabel} onClick={onClick}>
+    <a className={cl(styles.link, className)} href={href} aria-label={ariaLabel} onClick={onClick}>
       {children}
     </a>
   )
@@ -36,7 +36,7 @@ export default function Pagination() {
   }
 
   return (
-    <ul className={style.container}>
+    <ul className={styles.container}>
       {prev && (
         <li>
           <PageLink {...pageLinkProps(prev)} ariaLabel="Previous page">
@@ -53,13 +53,13 @@ export default function Pagination() {
             </PageLink>
           </li>
           <li>
-            <span className={style.filler}>...</span>
+            <span className={styles.filler}>...</span>
           </li>
         </>
       )}
 
       {pages.map(page => (
-        <li key={page.page} className={cl(page.current && style.active)}>
+        <li key={page.page} className={cl(page.current && styles.active)}>
           <PageLink ariaLabel={`${page.page} page`} {...pageLinkProps(page)}>
             {page.page}
           </PageLink>
@@ -69,7 +69,7 @@ export default function Pagination() {
       {last && (
         <>
           <li>
-            <span className={style.filler}>...</span>
+            <span className={styles.filler}>...</span>
           </li>
           <li>
             <PageLink {...pageLinkProps(last)} ariaLabel="Last page">

--- a/src/components/Products/Products.tsx
+++ b/src/components/Products/Products.tsx
@@ -1,7 +1,7 @@
 import { pick } from "@nosto/search-js/utils"
 import Product from "@/components/Product/Product"
 import { useDecoratedSearchResults, useNostoAppState } from "@nosto/search-js/preact/hooks"
-import style from "./Products.module.css"
+import styles from "./Products.module.css"
 import { cl } from "@nosto/search-js/utils"
 import { hitDecorators } from "@/config"
 
@@ -10,7 +10,7 @@ export default function Products() {
   const { products } = useDecoratedSearchResults<typeof hitDecorators>()
 
   return (
-    <div className={cl(style.container, loading && style.loading)}>
+    <div className={cl(styles.container, loading && styles.loading)}>
       {products?.hits.map((hit, index) => {
         return <Product product={hit} key={hit.productId || index} />
       })}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,7 +1,7 @@
 import { AutocompletePageProvider } from "@nosto/search-js/preact/autocomplete"
 import AutocompleteNative from "@/components/Autocomplete/AutocompleteNative"
 import { autocompleteConfig } from "@/config"
-import style from "./Search.module.css"
+import styles from "./Search.module.css"
 import { useActions } from "@nosto/search-js/preact/hooks"
 import { useCallback } from "preact/hooks"
 import { nostojs } from "@nosto/nosto-js"
@@ -19,7 +19,7 @@ export default function Search() {
   )
 
   return (
-    <div className={style.wrapper}>
+    <div className={styles.wrapper}>
       <AutocompletePageProvider config={autocompleteConfig}>
         <AutocompleteNative onSubmit={onSubmit} />
       </AutocompletePageProvider>

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -2,7 +2,7 @@ import { useNostoAppState, useSelectedFiltersCount, useSort, useSizeOptions } fr
 import { pick } from "@nosto/search-js/utils"
 import { sortOptions, defaultSize, sizes } from "@/config"
 import Select from "@/elements/Select/Select"
-import style from "./Toolbar.module.css"
+import styles from "./Toolbar.module.css"
 import Button from "@/elements/Button/Button"
 import { cl } from "@nosto/search-js/utils"
 import { useFilterSidebar } from "@/contexts/SidebarContext"
@@ -16,11 +16,11 @@ function ToggleFilterSidebarButton({ selectedFiltersCount, className }: Props) {
   const { toggle } = useFilterSidebar()
 
   return (
-    <Button light className={cl(style.filter, className)} onClick={toggle}>
-      <div className={style.label}>
+    <Button light className={cl(styles.filter, className)} onClick={toggle}>
+      <div className={styles.label}>
         <span>Filter</span>
       </div>
-      {selectedFiltersCount > 0 && <span className={style.badge}>{selectedFiltersCount}</span>}
+      {selectedFiltersCount > 0 && <span className={styles.badge}>{selectedFiltersCount}</span>}
     </Button>
   )
 }
@@ -34,20 +34,20 @@ export default function Toolbar() {
   const options = sortOptions.map(o => ({ value: o.id, label: o.value.name }))
 
   return (
-    <div className={cl(style.container, loading && style.loading)}>
-      <div className={style.leftSide}>
+    <div className={cl(styles.container, loading && styles.loading)}>
+      <div className={styles.leftSide}>
         <ToggleFilterSidebarButton selectedFiltersCount={selectedFiltersCount} />
       </div>
-      <div className={style.rightSide}>
+      <div className={styles.rightSide}>
         {!loading && (
-          <span className={style.total} data-nosto-element="totalResults">
+          <span className={styles.total} data-nosto-element="totalResults">
             {from} - {total < to ? total : to} of {total} items
           </span>
         )}
         <Select
           value={activeSort}
           onChange={e => setSort((e.target as HTMLSelectElement)?.value)}
-          className={style.sortMenu}
+          className={styles.sortMenu}
           options={options}
           label={"Sort by"}
         />

--- a/src/elements/Checkbox/Checkbox.tsx
+++ b/src/elements/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import style from "./Checkbox.module.css"
+import styles from "./Checkbox.module.css"
 import { cl } from "@nosto/search-js/utils"
 
 type Props = {
@@ -10,10 +10,10 @@ type Props = {
 
 export default function Checkbox({ value, selected, onChange, className }: Props) {
   return (
-    <label className={cl(style.checkbox, className)}>
+    <label className={cl(styles.checkbox, className)}>
       {value}
       <input type="checkbox" checked={selected} onChange={onChange} />
-      <span className={style.checkmark} />
+      <span className={styles.checkmark} />
     </label>
   )
 }

--- a/src/elements/Heading/Heading.tsx
+++ b/src/elements/Heading/Heading.tsx
@@ -1,5 +1,5 @@
 import { ComponentChildren } from "preact"
-import style from "./Heading.module.css"
+import styles from "./Heading.module.css"
 
 type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
 
@@ -10,5 +10,5 @@ type HeadingProps = {
 
 export default function Heading({ as = "h3", children }: HeadingProps) {
   const Tag = as
-  return <Tag className={style.heading}>{children}</Tag>
+  return <Tag className={styles.heading}>{children}</Tag>
 }

--- a/src/elements/RadioButton/RadioButton.tsx
+++ b/src/elements/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import style from "./RadioButton.module.css"
+import styles from "./RadioButton.module.css"
 import { cl } from "@nosto/search-js/utils"
 
 type Props = {
@@ -11,10 +11,10 @@ type Props = {
 
 export default function RadioButton({ value, selected, onChange, className, name }: Props) {
   return (
-    <label className={cl(style.radioButton, className)}>
+    <label className={cl(styles.radioButton, className)}>
       {value}
       <input type="radio" name={name} checked={selected} onChange={onChange} />
-      <span className={style.checkmark} />
+      <span className={styles.checkmark} />
     </label>
   )
 }


### PR DESCRIPTION
## Summary
- standardize CSS module default imports from style to styles across remaining components and elements
- leave real DOM style mutations untouched

## Validation
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run lint (passes with existing usePopState hook warnings)
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run typecheck
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run test
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run test:e2e