### PR TITLE
[codex] Default Button type to button

### DIFF
--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -8,9 +8,9 @@ type Props = {
   light?: boolean
 } & JSX.IntrinsicElements["button"]
 
-export default function Button({ className, icon, children, light, ...props }: Props) {
+export default function Button({ className, icon, children, light, type = "button", ...props }: Props) {
   return (
-    <button className={cl(styles.button, light && styles.light, className)} {...props}>
+    <button className={cl(styles.button, light && styles.light, className)} type={type} {...props}>
       {icon && <Icon name={icon} />}
       {children}
     </button>


### PR DESCRIPTION
## Summary
- Default the shared Button component type prop to button
- Preserve support for explicit native button types like submit and reset

## Validation
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:/Users/timo.westkamper/.codex/tmp/arg0/codex-arg0Xiwnsl:/opt/homebrew/opt/openjdk@21/bin:/opt/homebrew/opt/openjdk@17/bin:/Users/timo.westkamper/.nvm/versions/node/v18.20.4/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources npm run lint
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:/Users/timo.westkamper/.codex/tmp/arg0/codex-arg0Xiwnsl:/opt/homebrew/opt/openjdk@21/bin:/opt/homebrew/opt/openjdk@17/bin:/Users/timo.westkamper/.nvm/versions/node/v18.20.4/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources npm run test
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:/Users/timo.westkamper/.codex/tmp/arg0/codex-arg0Xiwnsl:/opt/homebrew/opt/openjdk@21/bin:/opt/homebrew/opt/openjdk@17/bin:/Users/timo.westkamper/.nvm/versions/node/v18.20.4/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources npm run typecheck
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:/Users/timo.westkamper/.codex/tmp/arg0/codex-arg0Xiwnsl:/opt/homebrew/opt/openjdk@21/bin:/opt/homebrew/opt/openjdk@17/bin:/Users/timo.westkamper/.nvm/versions/node/v18.20.4/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources npm run test:e2e