### PR TITLE
[codex] Enable dense flow for products grid

### DIFF
--- a/src/components/Products/Products.module.css
+++ b/src/components/Products/Products.module.css
@@ -1,5 +1,6 @@
 .container {
   display: grid;
+  grid-auto-flow: dense;
   grid-template-columns: 1fr;
   transition: opacity 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- add `grid-auto-flow: dense` to the products grid container
- allow CSS grid to backfill gaps more efficiently when larger items or disruptors are present

## Validation
- `npm run lint` (passes with existing warnings in `src/hooks/usePopState.ts`)
- `npm run test`
- `npm run test:e2e`
- `npm run typecheck`
- `npm run style-lint`