### PR TITLE
[codex] Remove selected range filter

### DIFF
--- a/src/components/FilterSidebar/RangeSelector/RangeSelector.tsx
+++ b/src/components/FilterSidebar/RangeSelector/RangeSelector.tsx
@@ -2,7 +2,7 @@ import { useState } from "preact/hooks"
 import Icon from "@/elements/Icon/Icon"
 import RadioButton from "@/elements/RadioButton/RadioButton"
 import { SearchStatsFacet } from "@nosto/nosto-js/client"
-import { useRangeSelector } from "@nosto/search-js/preact/hooks"
+import { useActions, useRangeSelector } from "@nosto/search-js/preact/hooks"
 import styles from "./RangeSelector.module.css"
 import { cl } from "@nosto/search-js/utils"
 
@@ -17,6 +17,7 @@ type Props = {
 
 export default function RangeSelector({ facet, rangeSize = 100, defaultActive = false }: Props) {
   const { ranges, updateRange } = useRangeSelector(facet.id, rangeSize)
+  const { replaceFilter } = useActions()
   const [active, setActive] = useState(defaultActive)
 
   const toggleActive = () => {
@@ -24,6 +25,15 @@ export default function RangeSelector({ facet, rangeSize = 100, defaultActive = 
   }
 
   const selectedCount = ranges.filter(r => r.selected).length
+
+  const handleRangeChange = (rangeItem: (typeof ranges)[number]) => {
+    if (rangeItem.selected) {
+      replaceFilter(facet.field!, undefined)
+      return
+    }
+
+    updateRange([rangeItem.min, rangeItem.max])
+  }
 
   // TODO currency formatting for price ranges
 
@@ -57,9 +67,12 @@ export default function RangeSelector({ facet, rangeSize = 100, defaultActive = 
               name={`${facet.id}-range`}
               value={`${rangeItem.min} - ${rangeItem.max}`}
               selected={rangeItem.selected ?? false}
-              onChange={() =>
-                rangeItem.selected ? updateRange([undefined, undefined]) : updateRange([rangeItem.min, rangeItem.max])
-              }
+              onChange={() => handleRangeChange(rangeItem)}
+              onClick={() => {
+                if (rangeItem.selected) {
+                  handleRangeChange(rangeItem)
+                }
+              }}
               className={styles.rangeItem}
             />
           ))}

--- a/src/elements/RadioButton/RadioButton.tsx
+++ b/src/elements/RadioButton/RadioButton.tsx
@@ -5,15 +5,16 @@ type Props = {
   value: string
   selected: boolean
   onChange: (e: Event) => void
+  onClick?: (e: MouseEvent) => void
   className?: string
   name: string
 }
 
-export default function RadioButton({ value, selected, onChange, className, name }: Props) {
+export default function RadioButton({ value, selected, onChange, onClick, className, name }: Props) {
   return (
     <label className={cl(styles.radioButton, className)}>
       {value}
-      <input type="radio" name={name} checked={selected} onChange={onChange} />
+      <input type="radio" name={name} checked={selected} onChange={onChange} onClick={onClick} />
       <span className={styles.checkmark} />
     </label>
   )

--- a/test/components/FilterSidebar/RangeSelector.spec.tsx
+++ b/test/components/FilterSidebar/RangeSelector.spec.tsx
@@ -1,0 +1,68 @@
+import { render, fireEvent } from "@testing-library/preact"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import RangeSelector from "@/components/FilterSidebar/RangeSelector/RangeSelector"
+import * as hooks from "@nosto/search-js/preact/hooks"
+import { SearchStatsFacet } from "@nosto/nosto-js/client"
+
+vi.mock("@nosto/search-js/preact/hooks", () => ({
+  useActions: vi.fn(),
+  useRangeSelector: vi.fn()
+}))
+
+describe("RangeSelector", () => {
+  const mockFacet: SearchStatsFacet = {
+    id: "price",
+    name: "Price",
+    field: "price",
+    type: "stats",
+    min: 0,
+    max: 200
+  }
+
+  const mockUpdateRange = vi.fn()
+  const mockReplaceFilter = vi.fn()
+
+  beforeEach(() => {
+    mockUpdateRange.mockClear()
+    mockReplaceFilter.mockClear()
+
+    vi.mocked(hooks.useActions).mockReturnValue({
+      newSearch: vi.fn(),
+      updateSearch: vi.fn(),
+      toggleProductFilter: vi.fn(),
+      replaceFilter: mockReplaceFilter
+    })
+
+    vi.mocked(hooks.useRangeSelector).mockReturnValue({
+      min: 0,
+      max: 200,
+      range: [0, 100],
+      ranges: [
+        { min: 0, max: 100, selected: true },
+        { min: 100, max: 200, selected: false }
+      ],
+      updateRange: mockUpdateRange,
+      handleMinChange: vi.fn(),
+      handleMaxChange: vi.fn(),
+      isSelected: true
+    })
+  })
+
+  it("removes the range filter when the selected range changes", () => {
+    const { getByLabelText } = render(<RangeSelector facet={mockFacet} defaultActive />)
+
+    fireEvent.click(getByLabelText("0 - 100"))
+
+    expect(mockReplaceFilter).toHaveBeenCalledWith("price", undefined)
+    expect(mockUpdateRange).not.toHaveBeenCalled()
+  })
+
+  it("updates the range when an unselected range changes", () => {
+    const { getByLabelText } = render(<RangeSelector facet={mockFacet} defaultActive />)
+
+    fireEvent.click(getByLabelText("100 - 200"))
+
+    expect(mockUpdateRange).toHaveBeenCalledWith([100, 200])
+    expect(mockReplaceFilter).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Remove selected range filters with replaceFilter(field, undefined) instead of clearing through updateRange.
- Keep the idiomatic JSX onChange selection path for unselected range values.
- Add a selected-click path for native radio inputs, since checked radios do not emit change when clicked again.
- Cover selected and unselected range behavior with a focused RangeSelector unit test.

## Validation
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run test
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run typecheck
- PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run lint