### PR TITLE
[codex] Remove skill name prefixes

### DIFF
--- a/.agents/skills/search-templates-preact/SKILL.md
+++ b/.agents/skills/search-templates-preact/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: search-templates-preact
+name: preact
 description: Project Preact component conventions for Search Templates Starter. Use when editing or creating TSX Preact components matching **/*.tsx, including components that read Nosto app state.
 ---
 

--- a/.agents/skills/search-templates-storybook/SKILL.md
+++ b/.agents/skills/search-templates-storybook/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: search-templates-storybook
+name: storybook
 description: Project Storybook story conventions for Search Templates Starter. Use when editing or creating Storybook files matching **/*.stories.tsx, especially stories for real Preact components.
 ---
 

--- a/.agents/skills/search-templates-testing/SKILL.md
+++ b/.agents/skills/search-templates-testing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: search-templates-testing
+name: testing
 description: Project Vitest conventions for Search Templates Starter. Use when editing or creating test files under test/**/*, including jsdom and @testing-library/preact based tests.
 ---
 

--- a/.agents/skills/search-templates-typescript/SKILL.md
+++ b/.agents/skills/search-templates-typescript/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: search-templates-typescript
+name: typescript
 description: Project TypeScript and JavaScript conventions for Search Templates Starter. Use when editing or creating TypeScript or TSX files matching **/*.ts or **/*.tsx in this Preact, Vite, and @nosto/search-js codebase.
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,11 +64,11 @@ This starts Storybook at http://localhost:6060.
 
 ## Codex Skills
 
-File-pattern-specific coding conventions are now documented as project-local Codex skills in `.codex/skills/`:
+File-pattern-specific coding conventions are now documented as project-local Codex skills in `.agents/skills/`:
 
-- **TypeScript/JavaScript** (`**/*.ts`, `**/*.tsx`): `$search-templates-typescript`
-- **Testing** (`test/**/*`): `$search-templates-testing`
-- **Storybook Stories** (`**/*.stories.tsx`): `$search-templates-storybook`
-- **Preact Components** (`**/*.tsx`): `$search-templates-preact`
+- **TypeScript/JavaScript** (`**/*.ts`, `**/*.tsx`): `$typescript`
+- **Testing** (`test/**/*`): `$testing`
+- **Storybook Stories** (`**/*.stories.tsx`): `$storybook`
+- **Preact Components** (`**/*.tsx`): `$preact`
 
-Use the most specific matching skill first when modifying or creating files. For `*.stories.tsx`, use `$search-templates-storybook` as the primary skill; use `$search-templates-preact` for non-story TSX components. Apply `$search-templates-typescript` alongside the more specific skill when general TypeScript guidance is relevant.
+Use the most specific matching skill first when modifying or creating files. For `*.stories.tsx`, use `$storybook` as the primary skill; use `$preact` for non-story TSX components. Apply `$typescript` alongside the more specific skill when general TypeScript guidance is relevant.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ npm run storybook
 
 No merchant ID is required as the components in Storybook are sandboxed.
 
+### Codex skills
+
+This repository includes project-local Codex skills in `.agents/skills/` for common development tasks:
+
+- `typescript` for TypeScript and JavaScript conventions.
+- `preact` for TSX Preact component conventions.
+- `storybook` for Storybook story conventions.
+- `testing` for Vitest test conventions.
+
+Use the most specific skill for the files you are editing. For example, use `storybook` for `*.stories.tsx` files and `preact` for non-story TSX components. Apply `typescript` alongside the more specific skill when general TypeScript guidance is relevant.
+
 ## Developing live
 
 Using the Nosto CLI, you may also deploy the template straight to your store in preview mode. Note that any changes you do through Nosto CLI will only be visible with the Debug Toolbar and preview mode enabled. Production deployments are done through the Nosto Admin system.


### PR DESCRIPTION
## Summary

- Rename project-local Codex skill frontmatter names to unprefixed names: `typescript`, `preact`, `storybook`, and `testing`.
- Update `AGENTS.md` to reference the unprefixed skill names and the actual `.agents/skills/` location.
- Document the project-local Codex skills in `README.md`.

## Validation

- `git diff --cached --check` before commit
- `git diff --check` before staging