### PR TITLE
fix(deps): update vulnerable fast-uri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6620,9 +6620,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Update transitive `fast-uri` lockfile entry from 3.1.0 to 3.1.2 to resolve npm audit advisories.

## Validation
- `npm audit --json`
- `PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run lint` (passes with existing warnings in `src/hooks/usePopState.ts`)
- `PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run test`
- `PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run typecheck`
- `PATH=/Users/timo.westkamper/.nvm/versions/node/v24.11.1/bin:$PATH npm run test:e2e`

Notes: default shell Node is v18.20.4 and Vitest requires a newer Node because `node:util.styleText` is imported by current dependencies, so validation was run with local Node v24.11.1.
