### PR TITLE
fix: exclude stylelint and e2e in clone repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    if: ${{ github.event.repository.name == 'search-templates-starter' }}
     steps:
       - name: Checkout current branch
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -52,6 +51,24 @@ jobs:
 
       - name: Run lint
         run: npm run lint
+  stylelint:
+    name: Stylelint
+    runs-on: ubuntu-latest
+    if: ${{ github.event.repository.name == 'search-templates-starter' }}
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup Node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
 
       - name: Run style lint
         run: npm run style-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Run injected build
         run: npm run build
 
@@ -46,9 +43,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Run lint
         run: npm run lint
   stylelint:
@@ -67,9 +61,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Run style lint
         run: npm run style-lint
   e2e:
@@ -87,9 +78,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Build demo app
         run: npm run build:demo
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         run: npm run lint
 
       - name: Run style lint
+        if: ${{ github.event.repository.name == 'search-templates-starter' }}
         run: npm run style-lint
 
       - name: Run typecheck
@@ -45,6 +46,7 @@ jobs:
         run: npm run test
 
       - name: Run E2E tests
+        if: ${{ github.event.repository.name == 'search-templates-starter' }}
         run: |
           npx playwright install --with-deps
           npm run test:e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Run lint
         run: npm run lint
 


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Enabled stylelint and e2e tests by default only in the main repository, not the clones

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->