### PR TITLE
chore: add vite client reference types

### DIFF
--- a/src/entries/dev.ts
+++ b/src/entries/dev.ts
@@ -13,7 +13,6 @@ type Context = {
 }
 
 function getContext(): Context {
-  // @ts-expect-error -- ENV VARIABLES --
   const { MODE, VITE_MERCHANT_ID, VITE_MERCHANT_DOMAIN } = import.meta.env
   const url = new URL(window.location.href)
   return {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 /**
  * If you are redirected here when you try to import a CSS module with VSCode,
  * you may want to do this to enable proper CSS type resolution in the IDE:


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Adds Vite client reference types to enable `import.meta.env` object access.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->